### PR TITLE
(fix): null VPNname

### DIFF
--- a/Public/ps1/Set-AzureVpnRoutes.ps1
+++ b/Public/ps1/Set-AzureVpnRoutes.ps1
@@ -104,6 +104,9 @@ function Set-AzureVpnRoutes {
 	[xml]$configXml = Get-Content $configXmlPath
 
     $vpnName = $configXml.AzVpnProfile.name.InnerText;
+    if ([string]::IsNullOrWhiteSpace($vpnName)) {
+        $vpnName = $configXml.AzVpnProfile.name;
+    }
 
 	# Navigate to the includeroutes node
     $includeRoutesNode = $configXml.SelectSingleNode("//*[local-name()='includeroutes']");


### PR DESCRIPTION
Fixed error where VPNname is null due to ".InnerText"